### PR TITLE
ci: derive Pages base path from repo name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,10 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+        env:
+          # Base path tracks the repo name, so renaming the repo (and thus the
+          # Pages URL /<repo>/) never breaks asset paths.
+          VITE_BASE: /${{ github.event.repository.name }}/
       - uses: actions/configure-pages@v5
         with:
           # Auto-create the Pages site (build type: GitHub Actions) so no manual

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ commits the MP4s back, which triggers a redeploy.
 
 `.github/workflows/deploy.yml` builds the app and deploys it to **GitHub Pages**. Enable Pages
 with the **GitHub Actions** source in repository settings. The site is served under
-`/hello-github-actions/`; `public/404.html` provides the SPA deep-link fallback.
+`/<repo-name>/` (the deploy workflow sets `VITE_BASE` from the repo name automatically);
+`public/404.html` provides the SPA deep-link fallback.
 
 ## Theming
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from "@vitejs/plugin-react";
 
 // GitHub Pages serves this project under /hello-github-actions/.
 // Allow overriding the base (e.g. "/") via VITE_BASE for local/Vercel builds.
-const base = process.env.VITE_BASE ?? "/hello-github-actions/";
+const base = process.env.VITE_BASE ?? "/chip-design/";
 
 export default defineConfig({
   base,


### PR DESCRIPTION
Makes the Vite `base` derive from the repository name (the deploy workflow passes `VITE_BASE=/${{ github.event.repository.name }}/`), so renaming the repo (e.g. to `chip-design`) updates the Pages base path automatically without breaking asset URLs. Also updates the local default base and README accordingly.

Prereq for renaming the repo to `chip-design`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPTEPmrnxWrmVMgJuF7N3f)_