### PR TITLE
docs: add live URL + trigger redeploy under chip-design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Chip Design From the Bottom Up
 
+**Live:** https://tushar1344.github.io/chip-design/
+
 An interactive book that builds an AI accelerator from first principles — from a single
 transistor acting as a switch, up to the systolic array at the heart of every TPU. It is a
 reconstruction of the Dwarkesh Patel × Reiner Pope lecture


### PR DESCRIPTION
Tiny docs change (adds the live URL) whose real purpose is to push to `main` and trigger a fresh GitHub Pages deploy now that the repo is renamed to `chip-design`. The build's base path derives from the repo name, so this run republishes the site at `/chip-design/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPTEPmrnxWrmVMgJuF7N3f)_