### PR TITLE
Make the book mobile-friendly

### DIFF
--- a/src/components/book/Sidebar.tsx
+++ b/src/components/book/Sidebar.tsx
@@ -1,8 +1,11 @@
-import { NavLink } from "react-router-dom";
+import { NavLink, useLocation, useNavigate } from "react-router-dom";
 import { chapters } from "../../content/chapters";
 
 /** Persistent left navigation: brand, chapter list, credits. */
 export function Sidebar() {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
   return (
     <aside className="sidebar">
       <NavLink className="brand" to="/">
@@ -10,6 +13,21 @@ export function Sidebar() {
         Chip Design
       </NavLink>
       <p className="brand-sub">from the bottom up</p>
+
+      {/* compact navigation for the mobile top bar */}
+      <select
+        className="chapter-select"
+        aria-label="Jump to chapter"
+        value={pathname}
+        onChange={(e) => navigate(e.target.value)}
+      >
+        <option value="/">Cover</option>
+        {chapters.map((c) => (
+          <option key={c.slug} value={`/chapter/${c.slug}`}>
+            {c.num}. {c.title}
+          </option>
+        ))}
+      </select>
 
       <p className="nav-label">Book</p>
       <nav className="nav">

--- a/src/simulations/CoreBudgetSim.tsx
+++ b/src/simulations/CoreBudgetSim.tsx
@@ -50,7 +50,12 @@ export function CoreBudgetSim() {
       </div>
 
       <div className="sim-row">
-        <svg width={GRID * CELL} height={GRID * CELL} style={{ display: "block" }}>
+        <svg
+          width={GRID * CELL}
+          height={GRID * CELL}
+          viewBox={`0 0 ${GRID * CELL} ${GRID * CELL}`}
+          style={{ display: "block", maxWidth: "100%", height: "auto" }}
+        >
           {Array.from({ length: TOTAL }).map((_, idx) => {
             const r = Math.floor(idx / GRID);
             const c = idx % GRID;

--- a/src/simulations/FabricSim.tsx
+++ b/src/simulations/FabricSim.tsx
@@ -39,7 +39,12 @@ export function FabricSim() {
       </div>
 
       <div className="sim-row">
-        <svg width={GRID * CELL} height={GRID * CELL} style={{ display: "block" }}>
+        <svg
+          width={GRID * CELL}
+          height={GRID * CELL}
+          viewBox={`0 0 ${GRID * CELL} ${GRID * CELL}`}
+          style={{ display: "block", maxWidth: "100%", height: "auto" }}
+        >
           {Array.from({ length: GRID * GRID }).map((_, idx) => {
             const r = Math.floor(idx / GRID);
             const c = idx % GRID;

--- a/src/simulations/LogicGateSim.tsx
+++ b/src/simulations/LogicGateSim.tsx
@@ -143,7 +143,7 @@ export function LogicGateSim() {
         </div>
       ) : (
         <div className="sim-row">
-          <svg width={360} height={170} style={{ display: "block", maxWidth: "100%" }}>
+          <svg width={360} height={170} viewBox="0 0 360 170" style={{ display: "block", maxWidth: "100%" }}>
             {/* input rails */}
             <text x={6} y={48} fontFamily="var(--mono)" fontSize={12} fill="var(--ink)">
               A

--- a/src/simulations/PipelineSim.tsx
+++ b/src/simulations/PipelineSim.tsx
@@ -75,8 +75,8 @@ export function PipelineSim() {
       </div>
 
       <div className="sim-row">
-        <div style={{ overflowX: "auto" }}>
-          <svg width={W} height={H} style={{ display: "block" }}>
+        <div className="scroll-x">
+          <svg width={W} height={H} style={{ display: "block", maxWidth: "none" }}>
             {/* cycle header */}
             {Array.from({ length: maxC }).map((_, c) => (
               <text

--- a/src/simulations/RooflineSim.tsx
+++ b/src/simulations/RooflineSim.tsx
@@ -36,7 +36,7 @@ export function RooflineSim() {
       </div>
 
       <div className="sim-row">
-        <svg width={W} height={H} style={{ display: "block" }}>
+        <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} style={{ display: "block", maxWidth: "100%", height: "auto" }}>
           {/* axes */}
           <line x1={PAD} y1={H - PAD} x2={W - 6} y2={H - PAD} stroke="var(--line-strong)" strokeWidth={1} />
           <line x1={PAD} y1={H - PAD} x2={PAD} y2={10} stroke="var(--line-strong)" strokeWidth={1} />

--- a/src/simulations/SystolicArraySim.tsx
+++ b/src/simulations/SystolicArraySim.tsx
@@ -81,7 +81,7 @@ export function SystolicArraySim() {
       </div>
 
       <div className="sim-row">
-        <svg width={W} height={H} style={{ display: "block", maxWidth: "100%" }}>
+        <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} style={{ display: "block", maxWidth: "100%" }}>
           {/* top B-feed labels */}
           {Array.from({ length: n }).map((_, j) => (
             <text

--- a/src/theme/site.css
+++ b/src/theme/site.css
@@ -559,6 +559,15 @@ main {
   transition: width 0.1s linear;
 }
 
+/* mobile chapter switcher — hidden on desktop, shown in the sticky top bar */
+.chapter-select { display: none; }
+
+/* any element that may be wider than the viewport scrolls instead of overflowing */
+.scroll-x { overflow-x: auto; -webkit-overflow-scrolling: touch; max-width: 100%; }
+
+/* make every simulation/diagram SVG scale to its container */
+.figure-card svg { max-width: 100%; height: auto; }
+
 /* ------------------------------------------------------------- responsive -- */
 
 @media (max-width: 1100px) {
@@ -570,14 +579,48 @@ main {
   .sidebar {
     position: sticky; top: 0; z-index: 20;
     height: auto;
-    display: flex; align-items: center; justify-content: space-between; gap: 16px;
-    padding: 12px 20px;
+    display: flex; align-items: center; justify-content: space-between; gap: 12px;
+    padding: 10px 16px;
     background: var(--paper);
     border-right: none; border-bottom: 1px solid var(--line);
   }
-  .brand { font-size: 18px; margin: 0; }
-  .brand-sub, .nav-label, .sidebar-foot, .sidebar nav:nth-of-type(2) { display: none; }
-  .sidebar nav:first-of-type { flex-direction: row; gap: 20px; margin: 0; }
-  .sidebar nav:first-of-type a { border-left: none; padding: 0; font-size: 14px; }
-  .prose h2, .prose h3 { scroll-margin-top: 68px; }
+  .brand { font-size: 17px; margin: 0; }
+  .brand-sub, .nav-label, .sidebar-foot, .sidebar .nav { display: none; }
+
+  /* swap the chapter list for a compact dropdown that fits the bar */
+  .chapter-select {
+    display: block;
+    max-width: 58%;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--ink);
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 7px 10px;
+  }
+
+  main { padding: 28px 18px 80px; }
+  .prose { font-size: 16px; }
+  .article-title { font-size: clamp(28px, 9vw, 40px); }
+  .hero h1 { font-size: clamp(30px, 9vw, 46px); }
+
+  .prose h2, .prose h3 { scroll-margin-top: 64px; }
+
+  /* roomier tap targets + no horizontal overflow inside figures */
+  .figure { margin: 28px 0; }
+  .figure-card { padding: 16px; }
+  .figure-card table { display: block; overflow-x: auto; white-space: nowrap; }
+  .sim-btn { padding: 9px 14px; }
+  .sim-stat-big { font-size: 36px; }
+
+  /* stack the home chapter rows a little tighter */
+  .chapter-row { gap: 12px; padding: 16px 0; }
+  .chapter-row .ch-num { width: 28px; }
+  .chapter-row .ch-tag { display: none; }
+}
+
+@media (max-width: 420px) {
+  main { padding: 22px 14px 72px; }
+  .chapter-select { max-width: 52%; }
 }


### PR DESCRIPTION
Makes the interactive book usable on phones:

- **Navigation:** the mobile top bar now has a compact chapter `<select>` (the desktop chapter list is hidden ≤820px), so you can jump between chapters on a phone.
- **Simulations:** every SVG gets a `viewBox` and scales to the container width; the wide pipeline space-time chart stays horizontally scrollable so its cells remain legible.
- **Layout:** tighter padding/typography at ≤820px and ≤420px, figure tables scroll instead of overflowing, larger tap targets on controls.

Type-checks and builds clean. Merges to `main` to redeploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPTEPmrnxWrmVMgJuF7N3f)_