### PR TITLE
fix: stack chapter title and blurb on the cover

### DIFF
--- a/src/theme/site.css
+++ b/src/theme/site.css
@@ -224,7 +224,7 @@ main {
   width: 42px;
   padding-top: 4px;
 }
-.chapter-row .ch-body { min-width: 0; }
+.chapter-row .ch-body { min-width: 0; display: flex; flex-direction: column; }
 .chapter-row .ch-name {
   font-family: var(--serif);
   font-size: 21px;


### PR DESCRIPTION
Fixes the cover/home page: each chapter row's title and one-line blurb were rendering run-on because `.ch-body` was an inline span. Making it a vertical flex column stacks the title above the blurb (and restores the blurb's top margin). Affects mobile and desktop.

Builds clean. Merges to `main` to redeploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPTEPmrnxWrmVMgJuF7N3f)_