### PR TITLE
fix: MAC table overflow on narrow phones

### DIFF
--- a/src/simulations/MacBuilderSim.tsx
+++ b/src/simulations/MacBuilderSim.tsx
@@ -122,7 +122,7 @@ export function MacBuilderSim() {
       <div style={{ marginTop: 22, paddingTop: 16, borderTop: "1px solid var(--line)" }}>
         <h4 style={{ margin: "0 0 14px" }}>2 · Accumulate a dot product — the MAC</h4>
         <div className="sim-row">
-          <div className="sim-col" style={{ minWidth: 280 }}>
+          <div className="sim-col" style={{ minWidth: 0 }}>
             <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: "var(--mono)", fontSize: 13 }}>
               <thead>
                 <tr style={{ color: "var(--muted)" }}>


### PR DESCRIPTION
Prevents a small-phone (~320px) overflow: the MAC dot-product table column had an inline `minWidth:280` that could exceed the figure-card width. Now it can shrink (`minWidth:0`), and the table already scrolls horizontally on mobile. Found via a layout audit at narrow breakpoints; other sims already scale/scroll correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPTEPmrnxWrmVMgJuF7N3f)_