### PR TITLE
fix: collapse cover layout to one column on mobile

### DIFF
--- a/src/theme/site.css
+++ b/src/theme/site.css
@@ -575,7 +575,9 @@ main {
   .rail { display: none; }
 }
 @media (max-width: 820px) {
-  .layout { grid-template-columns: 1fr; }
+  /* match .layout.no-rail's specificity so the cover collapses too */
+  .layout,
+  .layout.no-rail { grid-template-columns: 1fr; max-width: none; }
   .sidebar {
     position: sticky; top: 0; z-index: 20;
     height: auto;


### PR DESCRIPTION
Fixes the broken cover/home rendering on mobile (per screenshot): content was crammed into a narrow right column.

**Cause:** the home page uses `.layout.no-rail` (specificity 0,2,0), but the `@media (max-width: 820px)` single-column rule targeted only `.layout` (0,1,0), so it never overrode the two-column grid on the cover — leaving `260px + remainder`. Chapter pages use plain `.layout`, which is why they collapsed correctly.

**Fix:** the mobile rule now also targets `.layout.no-rail` (and resets `max-width`), so the cover collapses to a single column like every other page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPTEPmrnxWrmVMgJuF7N3f)_